### PR TITLE
encode tileset image path, handle absent layer.startx/y

### DIFF
--- a/src/Layer.js
+++ b/src/Layer.js
@@ -41,8 +41,8 @@ class Layer extends React.PureComponent {
     const { map } = this.props;
 
     const layerOffset = {
-      x: (layer.x + layer.startx) * map.tilewidth + (layer.offsetx || 0),
-      y: (layer.y + layer.starty) * map.tileheight + (layer.offsety || 0)
+      x: (layer.x + layer.startx || 0) * map.tilewidth + (layer.offsetx || 0),
+      y: (layer.y + layer.starty || 0) * map.tileheight + (layer.offsety || 0)
     };
 
     const zAuto = getLayerProperty(layer, "zAuto");

--- a/src/Tile.js
+++ b/src/Tile.js
@@ -45,7 +45,7 @@ class Tile extends React.PureComponent {
       <TileWrapper
         className="tiled-tile"
         style={{
-          "--tileset-image": `url(${mapPath}/${tileSet.image})`,
+          "--tileset-image": `url(${encodeURI(mapPath)}/${encodeURI(tileSet.image)})`,
           backgroundPosition: `${bgPos.x}px ${bgPos.y}px`,
           width: tileSet.tilewidth,
           height: tileSet.tileheight,


### PR DESCRIPTION
layer.startx/y was not set after I exported my map as json, which lead to css prop top and left was NaN,
also my image path had spaces which where not handled.
With this both issues were fixed for me.